### PR TITLE
feat: MVP frontend polish — login, landing page, pricing

### DIFF
--- a/apps/web/src/app/home/page.tsx
+++ b/apps/web/src/app/home/page.tsx
@@ -112,11 +112,11 @@ const steps = [
 const pricingPlans = [
   {
     name: 'Starter',
-    description: 'Teams processing up to 300 invoices/month',
-    price: 99,
+    description: 'Teams processing up to 500 invoices/month',
+    price: 299,
     period: 'month',
     features: [
-      'Up to 300 invoices/month',
+      'Up to 500 invoices/month',
       'OCR capture (PDF + email)',
       '5 user seats',
       'Single-level approval workflows',
@@ -129,9 +129,9 @@ const pricingPlans = [
     gradient: 'capture' as const,
   },
   {
-    name: 'Professional',
-    description: 'Growing AP teams, 300–2,000 invoices/month',
-    price: 299,
+    name: 'Growth',
+    description: 'Growing AP teams, 500–2,000 invoices/month',
+    price: 599,
     period: 'month',
     features: [
       'Up to 2,000 invoices/month',
@@ -149,23 +149,42 @@ const pricingPlans = [
     gradient: 'primary' as const,
   },
   {
-    name: 'Enterprise',
-    description: 'High-volume teams with complex requirements',
-    price: 999,
+    name: 'Scale',
+    description: 'High-volume AP, 2,000–5,000 invoices/month',
+    price: 1199,
     period: 'month',
     features: [
       'Up to 5,000 invoices/month',
+      '50 user seats',
+      'Multi-level approval routing',
+      'Custom integrations via API',
+      'Advanced analytics & reporting',
+      'Dedicated onboarding',
+      'SLA with uptime guarantee',
+      'Priority support',
+    ],
+    cta: 'Start Free Trial',
+    popular: false,
+    gradient: 'vendor' as const,
+  },
+  {
+    name: 'Enterprise',
+    description: 'Custom solutions for complex requirements',
+    price: null,
+    period: 'month',
+    features: [
+      'Unlimited invoices',
       'Unlimited user seats',
       'SSO / SAML integration',
       'Custom integrations via API',
       'Data residency options',
-      'Dedicated onboarding & CSM',
+      'Dedicated CSM',
       'SLA with uptime guarantee',
-      'Custom contract available',
+      'Custom contract',
     ],
-    cta: 'Request a Demo',
+    cta: 'Contact Sales',
     popular: false,
-    gradient: 'vendor' as const,
+    gradient: 'reporting' as const,
   },
 ];
 
@@ -175,6 +194,36 @@ export default function LandingPage() {
 
   return (
     <div className="flex min-h-screen flex-col bg-background">
+
+      {/* Sticky Header */}
+      <header className="sticky top-0 z-50 border-b border-border/50 bg-background/80 backdrop-blur-lg">
+        <div className="container mx-auto px-4 flex items-center justify-between h-16">
+          <div className="flex items-center gap-2">
+            <div
+              className="flex h-9 w-9 items-center justify-center rounded-xl"
+              style={{ background: `linear-gradient(135deg, hsl(${colors.primary}), hsl(${colors.accent}))` }}
+            >
+              <FileText className="h-5 w-5 text-white" />
+            </div>
+            <span className="text-xl font-bold text-foreground">BillForge</span>
+          </div>
+          <nav className="hidden md:flex items-center gap-6 text-sm text-muted-foreground">
+            <Link href="#features" className="hover:text-foreground transition-colors">Features</Link>
+            <Link href="#how-it-works" className="hover:text-foreground transition-colors">How It Works</Link>
+            <Link href="#pricing" className="hover:text-foreground transition-colors">Pricing</Link>
+          </nav>
+          <div className="flex items-center gap-3">
+            <Link href="/login">
+              <Button variant="ghost" size="sm">Sign In</Button>
+            </Link>
+            <Link href="/login">
+              <GradientButton gradient="primary" size="sm">
+                Start Free Trial
+              </GradientButton>
+            </Link>
+          </div>
+        </div>
+      </header>
 
       {/* Hero Section */}
       <section id="hero" className="relative overflow-hidden py-24 md:py-36">
@@ -385,7 +434,7 @@ export default function LandingPage() {
             </p>
           </div>
 
-          <div className="mx-auto grid max-w-5xl gap-8 lg:grid-cols-3">
+          <div className="mx-auto grid max-w-6xl gap-6 md:grid-cols-2 lg:grid-cols-4">
             {pricingPlans.map((plan) => (
               <GradientCard
                 key={plan.name}
@@ -405,8 +454,14 @@ export default function LandingPage() {
                     <p className="text-sm text-muted-foreground mt-1">{plan.description}</p>
                   </div>
                   <div className="mb-6">
-                    <span className="text-4xl font-bold text-foreground">${plan.price}</span>
-                    <span className="text-muted-foreground text-sm">/{plan.period}</span>
+                    {plan.price !== null ? (
+                      <>
+                        <span className="text-4xl font-bold text-foreground">${plan.price.toLocaleString()}</span>
+                        <span className="text-muted-foreground text-sm">/{plan.period}</span>
+                      </>
+                    ) : (
+                      <span className="text-4xl font-bold text-foreground">Custom</span>
+                    )}
                   </div>
                   <ul className="mb-6 space-y-3">
                     {plan.features.map((feature) => (
@@ -433,10 +488,7 @@ export default function LandingPage() {
           </div>
 
           <p className="text-center text-sm text-muted-foreground mt-8">
-            Processing more than 5,000 invoices/month?{' '}
-            <Link href="/login" className="text-primary hover:underline font-medium">
-              Talk to us about custom volume pricing.
-            </Link>
+            All plans include a 14-day free trial. No credit card required.
           </p>
         </div>
       </section>

--- a/apps/web/src/app/login/page.tsx
+++ b/apps/web/src/app/login/page.tsx
@@ -29,9 +29,17 @@ export default function LoginPage() {
   const [showPassword, setShowPassword] = useState(false);
   const [formData, setFormData] = useState({
     tenantId: '11111111-1111-1111-1111-111111111111',
-    email: 'admin@sandbox.local',
-    password: 'sandbox123',
+    email: '',
+    password: '',
   });
+
+  const fillDemoCredentials = () => {
+    setFormData({
+      tenantId: '11111111-1111-1111-1111-111111111111',
+      email: 'admin@sandbox.local',
+      password: 'sandbox123',
+    });
+  };
 
   const handleSubmit = async (e: React.FormEvent) => {
     e.preventDefault();
@@ -94,7 +102,7 @@ export default function LoginPage() {
 
           <div className="pt-8">
             <p className="text-sm text-white/60">
-              Built for mid-market finance teams processing 300–5,000 invoices/month.
+              Modern AP automation for growing companies.
             </p>
           </div>
         </div>
@@ -184,6 +192,18 @@ export default function LoginPage() {
                 )}
               </button>
             </form>
+
+            {/* Demo CTA */}
+            <div className="text-center">
+              <button
+                type="button"
+                onClick={fillDemoCredentials}
+                className="text-sm text-primary hover:text-primary/80 font-medium transition-colors inline-flex items-center gap-1.5"
+              >
+                Try the demo
+                <ArrowRight className="w-3.5 h-3.5" />
+              </button>
+            </div>
 
             {/* Security note */}
             <div className="flex items-center justify-center gap-2 text-xs text-slate-400">

--- a/apps/web/src/app/page.tsx
+++ b/apps/web/src/app/page.tsx
@@ -4,6 +4,7 @@ import { useEffect } from 'react';
 import { useRouter } from 'next/navigation';
 import { useAuthStore } from '@/stores/auth';
 import { FileText } from 'lucide-react';
+import LandingPage from '@/app/home/page';
 
 export default function HomePage() {
   const router = useRouter();
@@ -34,12 +35,11 @@ export default function HomePage() {
     );
   }
 
-  // If authenticated, we'll redirect above. Otherwise, dynamically import marketing page.
-  if (!isAuthenticated) {
-    // Redirect to the marketing page for unauthenticated users
-    router.push('/home');
+  // Authenticated users redirect to dashboard (handled in useEffect)
+  if (isAuthenticated) {
     return null;
   }
 
-  return null;
+  // Unauthenticated users see the marketing/landing page
+  return <LandingPage />;
 }


### PR DESCRIPTION
## Summary

- **Login page cleanup**: Cleared pre-filled credentials for a clean form, added a "Try the demo →" button that auto-fills sandbox credentials (`admin@sandbox.local`), and updated the tagline to "Modern AP automation for growing companies"
- **Landing page routing**: Root `/` now renders the marketing page inline for unauthenticated users instead of redirecting to `/home`. Authenticated users are redirected to `/dashboard`
- **Landing page header**: Added a sticky navbar with BillForge branding, section navigation links, and "Sign In" / "Start Free Trial" CTA buttons
- **Pricing tiers updated**: Aligned with product strategy — Starter $299/mo, Growth $599/mo, Scale $1,199/mo, Enterprise (custom pricing). Changed to a 4-column grid layout
- **Dashboard & Reports verified**: Both pages use React Query to fetch data from API endpoints (`/api/v1/reports/*`). KPI metrics are API-driven; chart visualizations use the charts component library

## Test plan

- [ ] Visit `/` while logged out — should see the marketing landing page with sticky header
- [ ] Click "Sign In" in the header — navigates to `/login`
- [ ] Login page shows empty email/password fields
- [ ] Click "Try the demo →" — auto-fills `admin@sandbox.local` credentials
- [ ] Sign in with demo credentials — redirects to `/dashboard`
- [ ] Visit `/` while logged in — redirects to `/dashboard`
- [ ] Pricing section shows 4 tiers: Starter ($299), Growth ($599), Scale ($1,199), Enterprise (Custom)
- [ ] Dashboard renders KPI stats from API (no hardcoded values)
- [ ] Reports page renders chart components
- [ ] `pnpm typecheck` passes
- [ ] `pnpm build` succeeds

🤖 Generated with [Claude Code](https://claude.com/claude-code)