### PR TITLE
fix: replace corepack with direct pnpm install in Docker frontend build

### DIFF
--- a/docker/Dockerfile.frontend
+++ b/docker/Dockerfile.frontend
@@ -7,7 +7,7 @@ RUN apk add --no-cache libc6-compat
 WORKDIR /app
 
 # Install pnpm
-RUN corepack enable && corepack prepare pnpm@8.15.0 --activate
+RUN npm install -g pnpm@8.15.0
 
 # Copy package files
 COPY package.json pnpm-lock.yaml* pnpm-workspace.yaml ./
@@ -20,7 +20,7 @@ RUN pnpm install --frozen-lockfile
 FROM node:20-alpine AS builder
 WORKDIR /app
 
-RUN corepack enable && corepack prepare pnpm@8.15.0 --activate
+RUN npm install -g pnpm@8.15.0
 
 COPY --from=deps /app/node_modules ./node_modules
 COPY --from=deps /app/apps/web/node_modules ./apps/web/node_modules


### PR DESCRIPTION
## Problem

The frontend Docker build fails with:

```
ERR_PNPM_LOCKFILE_BREAKING_CHANGE  Lockfile /app/pnpm-lock.yaml not compatible with current pnpm
```

The lockfile is `lockfileVersion: '6.0'` (pnpm 8 format) and the Dockerfile pins `pnpm@8.15.0`, but `corepack prepare pnpm@8.15.0 --activate` on newer Node 20 Alpine images can behave unexpectedly and produce this compatibility error.

## Fix

Replace `corepack enable && corepack prepare pnpm@8.15.0 --activate` with `npm install -g pnpm@8.15.0` in both the `deps` and `builder` stages of `docker/Dockerfile.frontend`.

This avoids the corepack intermediary entirely and uses a direct install, which is more reliable across Node image versions.

## Verification

- Lockfile still uses `lockfileVersion: '6.0'` (confirmed)
- `pnpm install` succeeds with pnpm 8.15.0
- `pnpm build` succeeds — Next.js production build completes without errors